### PR TITLE
[fix] 내차만들기/견적요약모달 버그 수정

### DIFF
--- a/FrontEnd/my-car/src/mycar/components/common/SummaryModal.js
+++ b/FrontEnd/my-car/src/mycar/components/common/SummaryModal.js
@@ -132,7 +132,8 @@ function SummaryModal({
             <OptionContentDiv>
               <OptionDetailDiv>모델 {userCar.trim.name}</OptionDetailDiv>
               <OptionDetailDiv>
-                {userCar.trim.price.toLocaleString()} 원
+                {userCar.trim.price ? userCar.trim.price.toLocaleString() : '0'}{' '}
+                원
               </OptionDetailDiv>
             </OptionContentDiv>
             {userCar.engine && (
@@ -140,7 +141,10 @@ function SummaryModal({
                 <OptionContentDiv>
                   <OptionDetailDiv>엔진 {userCar.engine.name}</OptionDetailDiv>
                   <OptionDetailDiv>
-                    {userCar.engine.price.toLocaleString()}원
+                    {userCar.engine?.price
+                      ? userCar.engine.price.toLocaleString()
+                      : 0}
+                    원
                   </OptionDetailDiv>
                 </OptionContentDiv>
               </>
@@ -153,7 +157,10 @@ function SummaryModal({
                       바디타입 {userCar.bodyType.name}
                     </OptionDetailDiv>
                     <OptionDetailDiv>
-                      {userCar.bodyType.price.toLocaleString()}원
+                      {userCar.bodyType?.price
+                        ? userCar.bodyType.price.toLocaleString()
+                        : 0}
+                      원
                     </OptionDetailDiv>
                   </OptionContentDiv>
                 </>
@@ -167,7 +174,10 @@ function SummaryModal({
                       구동방식 {userCar.wheelDrive.name}
                     </OptionDetailDiv>
                     <OptionDetailDiv>
-                      {userCar.wheelDrive.price.toLocaleString()}원
+                      {userCar.wheelDrive?.price
+                        ? userCar.wheelDrive.price.toLocaleString()
+                        : 0}
+                      원
                     </OptionDetailDiv>
                   </OptionContentDiv>
                 </>
@@ -175,9 +185,14 @@ function SummaryModal({
             </OptionDetailDiv>
             <OptionDiv> 외장색상 / 내장색상</OptionDiv>
             <OptionContentDiv>
-              {userCar.outerColor.name}/{userCar.innerColor.name}
+              {userCar.outerColor?.name &&
+                `${userCar.outerColor.name}/${userCar.innerColor.name}`}
+              {/* {userCar.outerColor.name}/{userCar.innerColor.name} */}
               <OptionDetailDiv>
-                {userCar.outerColor.price.toLocaleString()}원
+                {userCar.outerColor?.price
+                  ? userCar.outerColor.price.toLocaleString()
+                  : 0}
+                원
               </OptionDetailDiv>
             </OptionContentDiv>
             <OptionDiv>선택옵션 {userCar.selectedOptions.length}</OptionDiv>


### PR DESCRIPTION
견적요약모달 옵셔널 체이닝 버그 이슈 수정했습니다
예를들어 userCar 상태 안에서 처음 engine 페이지에서 견적 요약보기를 클릭했을때  바디타입 아직 선택되지 않아서 
bodyType.price가 없을 때 price.toLocaleString()을 바로 참조하면 오류가 생겼습니다.
조건을 하나 더 달아서 해결했습니다!

[issue] #121