### PR TITLE
[feat] 내차만들기/완성페이지 스크롤 방지

### DIFF
--- a/FrontEnd/my-car/src/common/Alert.js
+++ b/FrontEnd/my-car/src/common/Alert.js
@@ -1,15 +1,17 @@
 import styled from 'styled-components';
 import palette from '../style/styleVariable';
 import { Link } from 'react-router-dom';
+import { useEffect, useRef } from 'react';
 const AlertBgDiv = styled.div`
   position: absolute;
-  top: 0;
+  top: ${({ $top }) => ($top ? `${$top}px` : 0)};
   left: 0;
   width: 100%;
   height: 100%;
   background-color: rgba(0, 0, 0, 0.2);
   z-index: 5;
   backdrop-filter: blur(6px);
+  display: ${({ $showCommonAlert }) => ($showCommonAlert ? 'block' : 'none')};
 `;
 
 const AlertDiv = styled.div`
@@ -89,53 +91,69 @@ function movePage(setShowCommonAlert) {
 }
 
 function Alert({ showCommonAlert, setShowCommonAlert, isMain, isAchiving }) {
-  if (showCommonAlert === true) {
-    return (
-      <AlertBgDiv>
-        <AlertDiv>
-          <AlertMsgDiv>
-            {/* <AlertMsg>내 차 만들기를 그만하시겠어요?</AlertMsg> */}
-            {isMain && (
-              <>
-                <AlertMsg>마이카이빙에 저장되었습니다.</AlertMsg>
-                <AlertMsg>
-                  <AlertMsgBold>메인 페이지</AlertMsgBold>로 이동하시겠습니까?
-                </AlertMsg>
-              </>
-            )}
-            {isAchiving && (
-              <>
-                <AlertMsg>마이카이빙에 저장되었습니다.</AlertMsg>
-                <AlertMsg>
-                  <AlertMsgBold>아카이빙</AlertMsgBold>으로 이동하시겠습니까?
-                </AlertMsg>
-              </>
-            )}
-          </AlertMsgDiv>
+  useEffect(() => {
+    const body = document.querySelector('body');
 
-          <AlertBtnDiv>
-            <BtnCancel onClick={() => closeAlert(setShowCommonAlert)}>
-              <AlertMsgBold>취소</AlertMsgBold>
-            </BtnCancel>
-            {isMain && (
-              <Link to="/main">
-                <BtnConfirm onClick={() => closeAlert(setShowCommonAlert)}>
-                  <AlertMsgBold>확인</AlertMsgBold>
-                </BtnConfirm>
-              </Link>
-            )}
-            {isAchiving && (
-              <Link to="/archiving">
-                <BtnConfirm onClick={() => closeAlert(setShowCommonAlert)}>
-                  <AlertMsgBold>확인</AlertMsgBold>
-                </BtnConfirm>
-              </Link>
-            )}
-          </AlertBtnDiv>
-        </AlertDiv>
-      </AlertBgDiv>
-    );
-  }
+    if (showCommonAlert) {
+      body.classList.add('no-scroll');
+    } else {
+      body.classList.remove('no-scroll');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showCommonAlert]);
+
+  const alertBg = useRef();
+  const scrollTop = document.documentElement.scrollTop;
+
+  return (
+    <AlertBgDiv
+      $showCommonAlert={showCommonAlert}
+      ref={alertBg}
+      $top={scrollTop}
+    >
+      <AlertDiv>
+        <AlertMsgDiv>
+          {/* <AlertMsg>내 차 만들기를 그만하시겠어요?</AlertMsg> */}
+          {isMain && (
+            <>
+              <AlertMsg>마이카이빙에 저장되었습니다.</AlertMsg>
+              <AlertMsg>
+                <AlertMsgBold>메인 페이지</AlertMsgBold>로 이동하시겠습니까?
+              </AlertMsg>
+            </>
+          )}
+          {isAchiving && (
+            <>
+              <AlertMsg>마이카이빙에 저장되었습니다.</AlertMsg>
+              <AlertMsg>
+                <AlertMsgBold>아카이빙</AlertMsgBold>으로 이동하시겠습니까?
+              </AlertMsg>
+            </>
+          )}
+        </AlertMsgDiv>
+
+        <AlertBtnDiv>
+          <BtnCancel onClick={() => closeAlert(setShowCommonAlert)}>
+            <AlertMsgBold>취소</AlertMsgBold>
+          </BtnCancel>
+          {isMain && (
+            <Link to="/main">
+              <BtnConfirm onClick={() => closeAlert(setShowCommonAlert)}>
+                <AlertMsgBold>확인</AlertMsgBold>
+              </BtnConfirm>
+            </Link>
+          )}
+          {isAchiving && (
+            <Link to="/archiving">
+              <BtnConfirm onClick={() => closeAlert(setShowCommonAlert)}>
+                <AlertMsgBold>확인</AlertMsgBold>
+              </BtnConfirm>
+            </Link>
+          )}
+        </AlertBtnDiv>
+      </AlertDiv>
+    </AlertBgDiv>
+  );
 }
 
 export default Alert;

--- a/FrontEnd/my-car/src/mycar/components/completePage/AnimationMovingCar.js
+++ b/FrontEnd/my-car/src/mycar/components/completePage/AnimationMovingCar.js
@@ -85,7 +85,10 @@ function AnimationMovingCar() {
   const { userCar } = useOutletContext();
 
   useEffect(() => {
+    const body = document.querySelector('body');
+    body.classList.add('no-scroll');
     const timer = setTimeout(() => {
+      body.classList.remove('no-scroll');
       setRemoveModal(true);
     }, 2800);
 

--- a/FrontEnd/my-car/src/style/globalStyle.js
+++ b/FrontEnd/my-car/src/style/globalStyle.js
@@ -23,6 +23,10 @@ time, mark, audio, video,input, textarea,select,option {
   vertical-align: baseline;
   scroll-behavior: smooth;
 }
+body.no-scroll {
+  height: 100%;
+  overflow: hidden;
+}
 
 img{
   -webkit-user-drag: none;


### PR DESCRIPTION
내차만들기에서 완성페이지 진입시 등장 애니메이션이 떠있는 시간 동안 스크롤을 방지하기 위해

```css 
body.no-scroll {
  height: 100%;
  overflow: hidden;
}
```
globalStyle에 요렇게 미리 정의해주고

```javascript
useEffect(() => {
    const body = document.querySelector('body');
    body.classList.add('no-scroll');
    const timer = setTimeout(() => {
      body.classList.remove('no-scroll');
      setRemoveModal(true);
    }, 2800);

    return () => clearTimeout(timer);
  }, []);
```

애니메이션 컴포넌트의 useEffect 안에서 classList를 add/remove 해주었습니다


<b> +) 내차만들기/완료페이지 Alert 등장 시 스크롤 고정 및 
스크롤 내린 상태에서 Alert 등장 시 딤 영역의 top-position 을 스크롤량으로 변경해주었습니다. </b>

```javascript

useEffect(() => {
    const body = document.querySelector('body');

    if (showCommonAlert) {
      body.classList.add('no-scroll');
    } else {
      body.classList.remove('no-scroll');
    }
    // eslint-disable-next-line react-hooks/exhaustive-deps
  }, [showCommonAlert]);

  const scrollTop = document.documentElement.scrollTop;

  return (
    <AlertBgDiv
      $showCommonAlert={showCommonAlert}
      $top={scrollTop}
    >
  //......

)

```



[issue] #86