### PR TITLE
[FE] 아카이빙/메인 클릭이벤트 및 context 설정

### DIFF
--- a/FrontEnd/my-car/src/archiving/components/OptReviewCard.js
+++ b/FrontEnd/my-car/src/archiving/components/OptReviewCard.js
@@ -9,6 +9,8 @@ import palette from '../../style/styleVariable';
 import { OptTag } from './OptSelectionBar';
 import { Tag } from '../../common/Tag';
 import { useNavigate } from 'react-router-dom';
+import { useContext } from 'react';
+import { OptionSelectValue } from '../../context/archiving/ArchivingProvider';
 
 const Container = styled.div`
   width: calc(1280px - 240px);
@@ -115,6 +117,7 @@ const CategoryWrap = styled.div`
 `;
 
 function OptReviewCard() {
+  const { activeStates } = useContext(OptionSelectValue);
   const navigate = useNavigate();
   const CardClick = ({ id }) => {
     navigate(`/archiving/${id}`);
@@ -129,7 +132,6 @@ function OptReviewCard() {
               <div>
                 <h1>펠리세이드 Le Blanc</h1>
                 <RestInfoChip>시승</RestInfoChip>
-                {/* <RestInfoChip>23년 7월 19일</RestInfoChip> */}
               </div>
               <span>디젤 2.2 / 4WD / 7인승</span>
             </TrimInfo>
@@ -148,9 +150,11 @@ function OptReviewCard() {
           <CategoryWrap>
             <h3>선택옵션</h3>
             <div>
-              <OptTag>컴포트 || 패키지</OptTag>
-              <OptTag>듀얼 와이드 선루프</OptTag>
-              <OptTag>20인치 블랙톤 전면 가공휠</OptTag>
+              <OptTag $isActive={activeStates[1]}>컴포트 || 패키지</OptTag>
+              <OptTag $isActive={activeStates[4]}>듀얼 와이드 선루프</OptTag>
+              <OptTag $isActive={activeStates[14]}>
+                20인치 블랙톤 전면 가공휠
+              </OptTag>
               {/* <OptTag>현대 스마트 센스</OptTag>
             <OptTag>현대 스마트 센스</OptTag> */}
             </div>

--- a/FrontEnd/my-car/src/archiving/components/OptReviewHeader.js
+++ b/FrontEnd/my-car/src/archiving/components/OptReviewHeader.js
@@ -1,10 +1,28 @@
-import { styled } from 'styled-components';
+import { css, styled } from 'styled-components';
 import { Body2Medium, Body2Regular, Heading2Bold } from '../../style/typo';
 import palette from '../../style/styleVariable';
+import {
+  OptionSelectAction,
+  OptionSelectValue,
+} from '../../context/archiving/ArchivingProvider';
+import { useContext } from 'react';
+import { ArchivingTabMenu } from '../../constant';
 
 export const Container = styled.div`
   width: 1280px;
   margin: 20px auto;
+`;
+
+const TabText = styled.span`
+  ${({ $isActive }) =>
+    $isActive
+      ? css`
+          ${Body2Medium}
+          font-weight: bolder;
+        `
+      : css`
+          ${Body2Regular}
+        `}
 `;
 
 const HeaderWrap = styled.div`
@@ -26,7 +44,7 @@ const TabWrap = styled.div`
 
   span {
     cursor: pointer;
-    ${Body2Regular}
+
     padding: 0 10px;
     &:first-child {
       padding-left: 0;
@@ -38,14 +56,27 @@ const TabWrap = styled.div`
 `;
 
 function OptReviewHeader() {
+  const { action } = useContext(OptionSelectAction);
+  const { activeTab } = useContext(OptionSelectValue);
+
+  const TabClick = ({ index }) => {
+    action.tab({ index });
+  };
+
   return (
     <Container>
       <HeaderWrap>
         <h1>사용후기</h1>
         <TabWrap>
-          <span>전체</span>
-          <span>구매</span>
-          <span>시승</span>
+          {ArchivingTabMenu.map((tab, index) => (
+            <TabText
+              $isActive={activeTab === index}
+              key={index}
+              onClick={() => TabClick({ index })}
+            >
+              {tab}
+            </TabText>
+          ))}
         </TabWrap>
       </HeaderWrap>
     </Container>

--- a/FrontEnd/my-car/src/archiving/components/OptSelectionBar.js
+++ b/FrontEnd/my-car/src/archiving/components/OptSelectionBar.js
@@ -1,6 +1,11 @@
-import { styled } from 'styled-components';
+import { css, styled } from 'styled-components';
 import palette from '../../style/styleVariable';
 import { Body3Regular } from '../../style/typo';
+import { useContext, useState } from 'react';
+import {
+  OptionSelectAction,
+  OptionSelectValue,
+} from '../../context/archiving/ArchivingProvider';
 
 const Container = styled.div`
   background-color: ${palette.Neutral};
@@ -11,45 +16,71 @@ const Container = styled.div`
 `;
 
 const TagWrap = styled.div`
-  width: calc(1280px - 284px);
+  width: calc(1280px - 180px);
   display: flex;
   flex-wrap: wrap;
   gap: 14px;
-  padding: 0 142px;
-  justify-content: center;
 `;
 
 export const OptTag = styled.button`
   border: 0;
-  background-color: #fff;
+
+  ${({ $isActive }) =>
+    $isActive
+      ? css`
+          background-color: #385da2;
+          color: ${palette.Neutral};
+        `
+      : css`
+          background-color: #fff;
+          color: ${palette.DarkGray};
+        `}
+
   border-radius: 4px;
   border: 0.5px solid var(--light-gray, #dcdcdc);
-  color: ${palette.DarkGray};
   ${Body3Regular}
   cursor: pointer;
   padding: 4px 12px;
 `;
 
+const Mock = [
+  { id: '1', name: '컴포트 || 패키지' },
+  { id: '2', name: '주차 보조 시스템 ||' },
+  { id: '3', name: '2열 통풍시트' },
+  { id: '4', name: '듀얼 와이드 선루프' },
+  { id: '5', name: '현대스마트센스 |' },
+  { id: '6', name: '빌트인 캠(보조배터리 포함)' },
+  { id: '7', name: '듀얼 머플러 패키지' },
+  { id: '8', name: '사이드스텝' },
+  { id: '9', name: '빌트인 공기청정기' },
+  { id: '10', name: '적외선 무릎워머' },
+  { id: '11', name: '차량 보호 필름' },
+  { id: '12', name: '프로텍션 매트 패키지 |' },
+  { id: '13', name: '20인치 다크 스퍼터링 휠' },
+  { id: '14', name: '20인치 블랙톤 전면 가공휠' },
+  { id: '15', name: '알콘 단조브레이크 휠 패키지' },
+];
+
 function OptSelectionBar() {
+  const { action } = useContext(OptionSelectAction);
+  const { activeStates } = useContext(OptionSelectValue);
+
+  const ClickOption = ({ id }) => {
+    action.select({ id });
+  };
+
   return (
     <Container>
       <TagWrap>
-        <OptTag>컴포트 || 패키지</OptTag>
-        <OptTag>컴포트 || 패키지</OptTag>
-        <OptTag>컴포트 || 패키지</OptTag>
-        <OptTag>컴포트 || 패키지</OptTag>
-        <OptTag>컴포트 || 패키지</OptTag>
-        <OptTag>컴포트 || 패키지</OptTag>
-        <OptTag>컴포트 || 패키지</OptTag>
-        <OptTag>컴포트 || 패키지</OptTag>
-        <OptTag>컴포트 || 패키지</OptTag>
-        <OptTag>컴포트 || 패키지</OptTag>
-        <OptTag>컴포트 || 패키지</OptTag>
-        <OptTag>컴포트 || 패키지</OptTag>
-        <OptTag>컴포트 || 패키지</OptTag>
-        <OptTag>컴포트 || 패키지</OptTag>
-        <OptTag>컴포트 || 패키지</OptTag>
-        <OptTag>컴포트 || 패키지</OptTag>
+        {Mock.map((list, index) => (
+          <OptTag
+            onClick={() => ClickOption({ id: list.id })}
+            key={index}
+            $isActive={activeStates[list.id]}
+          >
+            {list.name}
+          </OptTag>
+        ))}
       </TagWrap>
     </Container>
   );

--- a/FrontEnd/my-car/src/archiving/router/Archiving.js
+++ b/FrontEnd/my-car/src/archiving/router/Archiving.js
@@ -2,6 +2,7 @@ import { styled } from 'styled-components';
 import OptSelectionBar from '../components/OptSelectionBar';
 import OptReviewHeader from '../components/OptReviewHeader';
 import OptReviewCard from '../components/OptReviewCard';
+import ArchivingProvider from '../../context/archiving/ArchivingProvider';
 
 const Container = styled.div`
   width: 100%;
@@ -10,11 +11,13 @@ const Container = styled.div`
 
 function Archiving() {
   return (
-    <Container>
-      <OptSelectionBar />
-      <OptReviewHeader />
-      <OptReviewCard />
-    </Container>
+    <ArchivingProvider>
+      <Container>
+        <OptSelectionBar />
+        <OptReviewHeader />
+        <OptReviewCard />
+      </Container>
+    </ArchivingProvider>
   );
 }
 export default Archiving;

--- a/FrontEnd/my-car/src/constant.js
+++ b/FrontEnd/my-car/src/constant.js
@@ -136,3 +136,5 @@ export const PALISADE_URL = {
   price:
     'https://www.hyundai.com/contents/repn-car/catalog/palisade-2024-price.pdf',
 };
+
+export const ArchivingTabMenu = ['전체', '구매', '시승'];

--- a/FrontEnd/my-car/src/context/archiving/ArchivingProvider.js
+++ b/FrontEnd/my-car/src/context/archiving/ArchivingProvider.js
@@ -1,0 +1,31 @@
+import { createContext, useState } from 'react';
+
+export const OptionSelectValue = createContext();
+export const OptionSelectAction = createContext();
+
+function ArchivingProvider({ children }) {
+  const [activeStates, setActiveStates] = useState({}); //선택 옵션
+  const [activeTab, setActiveTab] = useState(0); // 선택 탭(전체/시승/구매)
+
+  const action = {
+    select: ({ id }) => {
+      setActiveStates((prevActiveStates) => ({
+        ...prevActiveStates,
+        [id]: !prevActiveStates[id],
+      }));
+    },
+    tab: ({ index }) => {
+      setActiveTab(index);
+    },
+  };
+
+  return (
+    <OptionSelectAction.Provider value={{ action }}>
+      <OptionSelectValue.Provider value={{ activeStates, activeTab }}>
+        {children}
+      </OptionSelectValue.Provider>
+    </OptionSelectAction.Provider>
+  );
+}
+
+export default ArchivingProvider;


### PR DESCRIPTION
<b> 옵션 태그칩 클릭 시 칩 스타일을 변경하고 옵션 카드에도 반영해주었습니다.</b>

https://github.com/softeerbootcamp-2nd/A4-FourEver/assets/101038390/381ce020-5241-479c-abe8-1cd396330dd3

<br/>

<b> 전체/시승/구매 탭 클릭시 클릭한 탭을 볼드처리 했습니다 </b>

https://github.com/softeerbootcamp-2nd/A4-FourEver/assets/101038390/6b58e7a3-e603-4c55-a660-e94c61511673


해당 Active 상태들을 모두 ArchivingProvider로 묶어 context로 관리해주었습니다!


[issue] #146