### PR TITLE
[feat] 카이빙 헤더 상태 관리

### DIFF
--- a/FrontEnd/my-car/src/Root.js
+++ b/FrontEnd/my-car/src/Root.js
@@ -17,7 +17,7 @@ function Root() {
         isMainBtn={isMainBtn}
         setIsMainBtn={setIsMainBtn}
       />
-      <HeaderValueContext.Provider value={{ isAccess }}>
+      <HeaderValueContext.Provider value={{ isAccess, isMainBtn }}>
         <HeaderActionContext.Provider value={{ setIsAccess }}>
           <Header
             setShowCommonAlert={setShowCommonAlert}

--- a/FrontEnd/my-car/src/archiving/RootArchiving.js
+++ b/FrontEnd/my-car/src/archiving/RootArchiving.js
@@ -1,11 +1,11 @@
-import { Outlet } from 'react-router-dom';
-import { styled } from 'styled-components';
+import { Outlet, useLocation } from 'react-router-dom';
 import ChivingHeader from '../common/ChivingHeader';
 
 function RootArchiving() {
+  const { state } = useLocation();
   return (
     <>
-      <ChivingHeader />
+      <ChivingHeader fromMycar={state} />
       <Outlet />
     </>
   );

--- a/FrontEnd/my-car/src/common/Alert.js
+++ b/FrontEnd/my-car/src/common/Alert.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import palette from '../style/styleVariable';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 const AlertBgDiv = styled.div`
@@ -83,15 +83,8 @@ const BtnConfirm = styled.button`
   cursor: pointer;
 `;
 
-function closeAlert(setShowCommonAlert) {
-  setShowCommonAlert(false);
-}
-
-function movePage(setShowCommonAlert) {
-  setShowCommonAlert(false);
-}
-
 function Alert({ showCommonAlert, setShowCommonAlert, isMainBtn }) {
+  const navigate = useNavigate();
   useEffect(() => {
     const body = document.querySelector('body');
 
@@ -137,6 +130,11 @@ function Alert({ showCommonAlert, setShowCommonAlert, isMainBtn }) {
       return;
   }
 
+  const closeAlert = () => {
+    setShowCommonAlert(false);
+    navigate(link, { state: { from: 'mycar' } });
+  };
+
   return (
     <AlertBgDiv
       $showCommonAlert={showCommonAlert}
@@ -153,11 +151,10 @@ function Alert({ showCommonAlert, setShowCommonAlert, isMainBtn }) {
           <BtnCancel onClick={() => closeAlert(setShowCommonAlert)}>
             <AlertMsgBold>취소</AlertMsgBold>
           </BtnCancel>
-          <Link to={link}>
-            <BtnConfirm onClick={() => closeAlert(setShowCommonAlert)}>
-              <AlertMsgBold>확인</AlertMsgBold>
-            </BtnConfirm>
-          </Link>
+
+          <BtnConfirm onClick={() => closeAlert(setShowCommonAlert)}>
+            <AlertMsgBold>확인</AlertMsgBold>
+          </BtnConfirm>
         </AlertBtnDiv>
       </AlertDiv>
     </AlertBgDiv>

--- a/FrontEnd/my-car/src/common/ChivingHeader.js
+++ b/FrontEnd/my-car/src/common/ChivingHeader.js
@@ -1,9 +1,11 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import palette from '../style/styleVariable';
-import { ReactComponent as ToBackSymbol } from '../assets/leftArrow.svg';
+import ToBackSymbol from '../assets/leftArrow.svg';
 import { ReactComponent as ArchivingLogo } from '../assets/archivingLogoBlack.svg';
 import { ReactComponent as CarLogo } from '../assets/carLogo.svg';
 import { Heading3Medium, Heading4Medium } from '../style/typo';
+import { useNavigate } from 'react-router-dom';
+import { myCarPagePath } from '../constant';
 const ChivingHeaderDiv = styled.div`
   width: calc(100% - 200px);
   height: 91px;
@@ -36,6 +38,7 @@ const ArchivingSymbolText = styled.span`
   ${Heading3Medium}
 `;
 const ToMycarDiv = styled.div`
+  visibility: ${({ $isShow }) => ($isShow ? 'visible' : 'hidden')};
   display: flex;
   justify-content: center;
   align-items: center;
@@ -46,17 +49,43 @@ const ToMycarText = styled.span`
   ${Heading4Medium}
 `;
 
-function ChivingHeader() {
+const GoBack = styled.img`
+  cursor: pointer;
+  ${({ $isShow }) =>
+    $isShow
+      ? css`
+          visibility: visible;
+          cursor: pointer;
+        `
+      : css`
+          visibility: hidden;
+          cursor: auto;
+        `};
+`;
+
+function ChivingHeader({ fromMycar }) {
+  const navigate = useNavigate();
+  const BackClick = () => {
+    navigate(-1);
+  };
+  const GoMyCar = () => {
+    navigate(`/mycar/${myCarPagePath[0]}`);
+  };
+
   return (
     <ChivingHeaderDiv>
-      <ToBackSymbol style={{ cursor: 'pointer' }} />
+      <GoBack
+        onClick={BackClick}
+        src={ToBackSymbol}
+        $isShow={fromMycar !== null}
+      />
       <ArchivingSymbolDiv>
         <ArchivingLogo />
         <ArchivingSymbolText>아카이빙</ArchivingSymbolText>
       </ArchivingSymbolDiv>
-      <ToMycarDiv>
+      <ToMycarDiv onClick={GoMyCar} $isShow={fromMycar === null}>
         <CarLogo />
-        <ToMycarText>내 차 만들기 바로가기</ToMycarText>
+        <ToMycarText> 내 차 만들기 바로가기</ToMycarText>
       </ToMycarDiv>
     </ChivingHeaderDiv>
   );

--- a/FrontEnd/my-car/src/common/Header.js
+++ b/FrontEnd/my-car/src/common/Header.js
@@ -1,9 +1,9 @@
 import styled from 'styled-components';
 import palette from '../style/styleVariable';
 import { Body4Medium, Heading4Bold } from '../style/typo';
-import { headerPageName } from '../constant';
+import { headerPageName, myCarPagePath } from '../constant';
 import { useContext } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { HeaderValueContext } from '../Root';
 import { ReactComponent as HyundaiLogo } from '../../src/assets/hyundaiLogo.svg';
 import { ReactComponent as HyundaiLeftDiv } from '../../src/assets/leftDivisionBar.svg';
@@ -68,13 +68,10 @@ const HyundaiLogoDiv = styled.div`
   cursor: pointer;
 `;
 
-function showAlert(setShowCommonAlert, setIsMainBtn, flag) {
-  setShowCommonAlert(true);
-  setIsMainBtn(flag);
-}
-
 function Header({ setShowCommonAlert, setIsMainBtn }) {
+  const navigate = useNavigate();
   const currentPath = useLocation().pathname.split('/')[1];
+  const currentSubPath = useLocation().pathname.split('/')[2];
   const { isAccess } = useContext(HeaderValueContext);
   let btnText;
 
@@ -89,6 +86,19 @@ function Header({ setShowCommonAlert, setIsMainBtn }) {
       btnText = '아카이빙';
       break;
     default:
+  }
+
+  function showAlert(flag) {
+    if (
+      currentPath === 'mycar' &&
+      currentSubPath === myCarPagePath[myCarPagePath.length - 1]
+    ) {
+      navigate('/archiving');
+      return;
+    }
+
+    setShowCommonAlert(true);
+    setIsMainBtn(flag);
   }
 
   if (useLocation().pathname !== '/main') {
@@ -110,9 +120,7 @@ function Header({ setShowCommonAlert, setIsMainBtn }) {
           {currentPath === 'archiving' && !isAccess ? (
             <></>
           ) : (
-            <ToCarivingBtn
-              onClick={() => showAlert(setShowCommonAlert, setIsMainBtn, false)}
-            >
+            <ToCarivingBtn onClick={() => showAlert(false)}>
               <ArchivingLogo />
               <ToCarivingBtnText>{btnText}</ToCarivingBtnText>
             </ToCarivingBtn>

--- a/FrontEnd/my-car/src/common/Header.js
+++ b/FrontEnd/my-car/src/common/Header.js
@@ -72,7 +72,7 @@ function Header({ setShowCommonAlert, setIsMainBtn }) {
   const navigate = useNavigate();
   const currentPath = useLocation().pathname.split('/')[1];
   const currentSubPath = useLocation().pathname.split('/')[2];
-  const { isAccess } = useContext(HeaderValueContext);
+  const { isAccess, isMainBtn } = useContext(HeaderValueContext);
   let btnText;
 
   switch (currentPath) {
@@ -93,7 +93,7 @@ function Header({ setShowCommonAlert, setIsMainBtn }) {
       currentPath === 'mycar' &&
       currentSubPath === myCarPagePath[myCarPagePath.length - 1]
     ) {
-      navigate('/archiving');
+      isMainBtn ? navigate('/main') : navigate('/archiving');
       return;
     }
 
@@ -105,9 +105,7 @@ function Header({ setShowCommonAlert, setIsMainBtn }) {
     return (
       <HeaderDiv>
         <HeaderElements>
-          <HyundaiLogoDiv
-            onClick={() => showAlert(setShowCommonAlert, setIsMainBtn, true)}
-          >
+          <HyundaiLogoDiv onClick={() => showAlert(true)}>
             <HyundaiLogo />
           </HyundaiLogoDiv>
           <HyundaiLeftDiv />


### PR DESCRIPTION
- 아카이빙 페이지를 내차만들기 페이지에서 진입한 경우와 그 외의 경우(메인페이지, 내차만들기 완성페이지)에 따라 카이빙 헤더 상태가 변경됩니다!

- 내차만들기 완성페이지에서 최상단 헤더에 있는 아카이빙 버튼을 클릭시 Alert 뜨지 않고 바로로 아카이빙 페이지로 이동합니다

https://github.com/softeerbootcamp-2nd/A4-FourEver/assets/101038390/02802c18-686a-4742-bfb3-3d6527c73ca2


[issue] #155