### PR TITLE
[FE] 360도 이미지 프리로딩

### DIFF
--- a/FrontEnd/my-car/src/mycar/routers/Color.js
+++ b/FrontEnd/my-car/src/mycar/routers/Color.js
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from 'react';
+import { useContext, useEffect, useLayoutEffect, useState } from 'react';
 import { useOutletContext } from 'react-router-dom';
 import { styled } from 'styled-components';
 import { Container } from './Model';
@@ -44,6 +44,26 @@ function Color() {
         select: inColorOptions[0],
       });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const CarColor = ['abyss', 'silver', 'blue', 'brown', 'gray', 'white'];
+
+  const preloadCarImg = () => {
+    CarColor.forEach((color) => {
+      const imagePaths = Array.from(
+        { length: 60 },
+        (_, index) =>
+          `http://hyundaimycar.store/rotation/${color}/${index + 1}.png`,
+      );
+      imagePaths.forEach((path) => {
+        const img = new Image();
+        img.src = path;
+      });
+    });
+  };
+  useLayoutEffect(() => {
+    preloadCarImg();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
## 360 이미지 프리로딩 적용

기존 방식인 외장색상을 각각 클릭할때마다 이미지를 60장씩 다운받지 않고
useLayoutEffect 훅을 사용하여 뷰가 렌더되기 전에 모든 color의 이미지 360 장을 전부 다운받는 함수를 넣어봤습니다
360장이 전부 다운되어 캐시된 이후에는 버벅임이 일어나지 않지만,  저장속도가 조금 느리기 때문에 저장되기 전에 색상을 바꾸거나 이미지를 돌리면 여전히 버벅이기 때문에 <b> **레이지 로딩 처리** </b> 나 다른 처리가 필요해보입니다
전부 다운되는데 3초정도 걸리는것 같은데... 캐시된 이후에 돌려보니까 확실히 괜찮아진 것 같아요!

https://github.com/softeerbootcamp-2nd/A4-FourEver/assets/101038390/d20cd071-7310-4704-b56f-6eb3e2ec942a

[issue] #144