### PR TITLE
[FE] 아카이빙 상세페이지 내 옵션카드 하위항목 구현

### DIFF
--- a/FrontEnd/my-car/src/archiving/components/DetailBanner.js
+++ b/FrontEnd/my-car/src/archiving/components/DetailBanner.js
@@ -155,14 +155,14 @@ function DetailBanner() {
             <ColorDetailDiv>
               <ColorTitleText>외장</ColorTitleText>
               <ColorContentText>
-                {data[ARCHIVINGDETAIL.SELECTEDCAR.FILED.INCOLOR]}
+                {data[ARCHIVINGDETAIL.SELECTEDCAR.FILED.EXCOLOR]}
               </ColorContentText>
             </ColorDetailDiv>
             <ColorDivisionDiv />
             <ColorDetailDiv>
               <ColorTitleText>내장</ColorTitleText>
               <ColorContentText>
-                {data[ARCHIVINGDETAIL.SELECTEDCAR.FILED.EXCOLOR]}
+                {data[ARCHIVINGDETAIL.SELECTEDCAR.FILED.INCOLOR]}
               </ColorContentText>
             </ColorDetailDiv>
           </ColorDiv>

--- a/FrontEnd/my-car/src/archiving/components/optDetailCard.js
+++ b/FrontEnd/my-car/src/archiving/components/optDetailCard.js
@@ -1,13 +1,13 @@
 import { styled } from 'styled-components';
 import palette from '../../style/styleVariable';
 import { Body3Regular, CaptionRegular, Heading3Medium } from '../../style/typo';
-import { ReactComponent as CardDivisionSvg } from '../../assets/optionCardDivision.svg';
+// import { ReactComponent as CardDivisionSvg } from '../../assets/optionCardDivision.svg';
 import { useContext, useState } from 'react';
 import { DataLoaderContext } from '../router/ArchivingDetail';
 import { ARCHIVINGDETAIL } from '../../constant';
 const CardDiv = styled.div`
   width: 307px;
-  height: 263px;
+  height: 320px;
   flex-shrink: 0;
   border-radius: 8px;
   border: 2px solid
@@ -16,7 +16,7 @@ const CardDiv = styled.div`
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+
   padding: 20px 12px;
   cursor: pointer;
   &:hover {
@@ -52,10 +52,15 @@ const CardImg = styled.img`
   height: auto;
 `;
 
+const CardTitleOptDiv = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
 const CardTitleDiv = styled.div`
   display: flex;
   gap: 6px;
-  margin: 8px 15px;
+  margin: 10px 2px;
 `;
 
 const CardNumber = styled.div`
@@ -77,6 +82,14 @@ const CardNumber = styled.div`
   justify-content: center;
   align-items: center;
 `;
+
+const CardDivisionSvg = styled.div`
+  width: 307px;
+  height: 1.5px;
+  background-color: #e4dcd3;
+  margin-bottom: 5px;
+`;
+
 const CardText = styled.span`
   ${Heading3Medium}
 `;
@@ -85,10 +98,9 @@ const CardTagDiv = styled.div`
   display: flex;
   width: 300px;
   flex-wrap: wrap;
-  height: 30px;
-  gap: 8px;
   align-items: center;
-  padding: 14px;
+  padding: 5px;
+  height: 80px;
   overflow: auto;
 `;
 const EachTagDiv = styled.div`
@@ -100,6 +112,20 @@ const EachTagDiv = styled.div`
   border-radius: 8px;
   background-color: ${palette.LightSand};
   width: max-content;
+  margin: 0 6px 6px 0;
+`;
+
+const PkgSubOptDiv = styled.div`
+  display: ${({ $isSelected }) => ($isSelected ? 'block' : 'none')};
+`;
+const PkgSubOptText = styled.span`
+  ${Heading3Medium}
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 24px; /* 150% */
+  letter-spacing: -0.32px;
+  color: ${palette.Primary};
 `;
 
 function OptDetailCard({ data, idx, isSelected, onClick }) {
@@ -110,13 +136,29 @@ function OptDetailCard({ data, idx, isSelected, onClick }) {
         <CardImg src={data.image}></CardImg>
       </CardImgDiv>
 
-      <CardTitleDiv>
-        <CardNumber>
-          {idx.toString().length < 2 ? '0' + (idx + 1) : idx + 1}
-        </CardNumber>
-        <CardText>{data.name}</CardText>
-      </CardTitleDiv>
-      <CardDivisionSvg style={{ margin: '0 auto' }} />
+      <CardTitleOptDiv>
+        <CardTitleDiv>
+          <CardNumber>
+            {idx.toString().length < 2 ? '0' + (idx + 1) : idx + 1}
+          </CardNumber>
+          <CardText>{data.name}</CardText>
+        </CardTitleDiv>
+        <PkgSubOptDiv $isSelected={isSelected}>
+          {data.subExtraOptionNameDTOs.length > 1 &&
+            data.subExtraOptionNameDTOs.map((elem, idx) => {
+              return (
+                <span>
+                  <PkgSubOptText>
+                    {elem.name}{' '}
+                    {idx < data.subExtraOptionNameDTOs.length - 1 && `•`}{' '}
+                  </PkgSubOptText>
+                </span>
+              );
+            })}
+        </PkgSubOptDiv>
+      </CardTitleOptDiv>
+
+      <CardDivisionSvg />
       <CardTagDiv>
         {data.extraOptionTagInfoDTOS.map((item) => {
           return <EachTagDiv>{item.name}</EachTagDiv>;

--- a/FrontEnd/my-car/src/archiving/components/optDetailCard.js
+++ b/FrontEnd/my-car/src/archiving/components/optDetailCard.js
@@ -116,7 +116,11 @@ const EachTagDiv = styled.div`
 `;
 
 const PkgSubOptDiv = styled.div`
-  display: ${({ $isSelected }) => ($isSelected ? 'block' : 'none')};
+  opacity: ${({ $isSelected }) => ($isSelected ? '1' : '0')};
+  height: ${({ $isSelected }) => ($isSelected ? '70px' : '0px')};
+  overflow: hidden;
+  margin: 0 8px 8px;
+  transition: all 0.4s ease;
 `;
 const PkgSubOptText = styled.span`
   ${Heading3Medium}
@@ -143,11 +147,11 @@ function OptDetailCard({ data, idx, isSelected, onClick }) {
           </CardNumber>
           <CardText>{data.name}</CardText>
         </CardTitleDiv>
-        <PkgSubOptDiv $isSelected={isSelected}>
-          {data.subExtraOptionNameDTOs.length > 1 &&
-            data.subExtraOptionNameDTOs.map((elem, idx) => {
+        {data.subExtraOptionNameDTOs.length > 1 && (
+          <PkgSubOptDiv $isSelected={isSelected}>
+            {data.subExtraOptionNameDTOs.map((elem, idx) => {
               return (
-                <span>
+                <span key={idx}>
                   <PkgSubOptText>
                     {elem.name}{' '}
                     {idx < data.subExtraOptionNameDTOs.length - 1 && `•`}{' '}
@@ -155,13 +159,14 @@ function OptDetailCard({ data, idx, isSelected, onClick }) {
                 </span>
               );
             })}
-        </PkgSubOptDiv>
+          </PkgSubOptDiv>
+        )}
       </CardTitleOptDiv>
 
       <CardDivisionSvg />
       <CardTagDiv>
         {data.extraOptionTagInfoDTOS.map((item) => {
-          return <EachTagDiv>{item.name}</EachTagDiv>;
+          return <EachTagDiv key={item.id}>{item.name}</EachTagDiv>;
         })}
       </CardTagDiv>
     </CardDiv>

--- a/FrontEnd/my-car/src/assets/optionCardDivision.svg
+++ b/FrontEnd/my-car/src/assets/optionCardDivision.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="302" height="2" viewBox="0 0 302 2" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" width="327" height="2" viewBox="0 0 302 2" fill="none">
   <path d="M0.949219 1L301.688 0.99997" stroke="#E4DCD3"/>
 </svg>


### PR DESCRIPTION
### 아카이빙 상세페이지 내 패키지 옵션 카드를 선택시 하위 항목들이 함께 보여진다.
#### 다른 카드를 선택 시 보여졌던 하위 항목들은 저절로 사라집니다.

https://github.com/softeerbootcamp-2nd/A4-FourEver/assets/62049151/8f81bea7-893e-4049-bf92-376f069a8b54

<br> 

## ++ 스타일 리팩토링 했습니다.(transition 적용)

https://github.com/softeerbootcamp-2nd/A4-FourEver/assets/62049151/509c5687-277f-4e0e-a4d2-4bb8a04a08bf


