### PR TITLE
[BE] /cars/1/car-review 결과가 정상적이지 못한 버그 수정

### DIFF
--- a/BackEnd/FourEver/src/main/java/A4/FourEver/domain/car/dto/CarMapper.java
+++ b/BackEnd/FourEver/src/main/java/A4/FourEver/domain/car/dto/CarMapper.java
@@ -44,7 +44,8 @@ public class CarMapper {
 
     public CarReviewOverviewSortedListDTO convertToSortedDTO(CarReviewOverviewListDTO dto) {
         List<CarReviewOverviewSortedDTO> overviewDTOList = dto.getCarReviewOverviewDTOs().stream()
-                .sorted(Comparator.comparingLong(CarReviewOverviewDTO::getCar_review_id))
+                .sorted(Comparator.comparing(CarReviewOverviewDTO::getCreated_at).reversed())
+                .limit(100)
                 .map(this::convertCarReview)
                 .collect(Collectors.toList());
 

--- a/BackEnd/FourEver/src/main/java/A4/FourEver/domain/car/repository/CarRepositoryDefaultImpl.java
+++ b/BackEnd/FourEver/src/main/java/A4/FourEver/domain/car/repository/CarRepositoryDefaultImpl.java
@@ -138,7 +138,7 @@ public class CarRepositoryDefaultImpl implements CarRepository {
                 "WHERE cr.id IN (SELECT car_review_id FROM RelevantReviews) " +
                 "AND cr.is_purchased = :isPurchase " +
                 "ORDER BY cr.created_at DESC " +
-                "LIMIT 100;";
+                "LIMIT 1400;";
 
 
         MapSqlParameterSource params = new MapSqlParameterSource();
@@ -192,7 +192,7 @@ public class CarRepositoryDefaultImpl implements CarRepository {
 
                 "WHERE cr.id IN (SELECT car_review_id FROM RelevantReviews) " +
                 "ORDER BY cr.created_at DESC " +
-                "LIMIT 100;";
+                "LIMIT 1400;";
 
         MapSqlParameterSource params = new MapSqlParameterSource();
         params.addValue("car_id", id);


### PR DESCRIPTION
- Limit 100이 반환하는 객체의 수가 100개가 아니라, row의 수가 100개 이므로 반환하는 객체의 수가 부족했다. -> Limit 1400으로 변경, 상위 100개의 객체만 반환
- 객체가 만들어진 날짜가 아니라 id를 기준으로 정렬되었던 에러 -> 만들어진 날짜를 기준으로 정렬

[issue] #154