### PR TITLE
[FE] 아카이빙/메인 리뷰카드 active 옵션칩 순서 버그 해결

### DIFF
--- a/FrontEnd/my-car/src/archiving/components/OptReviewCard.js
+++ b/FrontEnd/my-car/src/archiving/components/OptReviewCard.js
@@ -126,6 +126,14 @@ function OptReviewCard() {
     navigate(`/archiving/${id}`);
   };
 
+  function optChipSort(selectOptions) {
+    const filtered = selectOptions.filter((option) => activeStates[option.id]);
+    const remaining = selectOptions.filter(
+      (option) => !activeStates[option.id],
+    );
+    return [...filtered, ...remaining];
+  }
+
   return (
     <Container>
       {reviewList[ARCHIVING.FILED.REVIEW] ? (
@@ -163,7 +171,7 @@ function OptReviewCard() {
               <CategoryWrap>
                 <h3>선택옵션</h3>
                 <div>
-                  {review.extraOptionNameDTOs
+                  {optChipSort(review.extraOptionNameDTOs)
                     .slice(0, 4)
                     .map((option, index) => (
                       <OptTag key={index} $isActive={activeStates[option.id]}>


### PR DESCRIPTION
## 옵션칩 순서 버그

아카이빙 메인 페이지에서 어떤 옵션칩을 선택했을때 나타나는 리뷰카드 안의 옵션 리스트에서 
해당 리뷰의 선택 옵션들이 너무 길 경우 4개까지만 노출되게끔 slice 되는데 선택한 옵션도 slice 되어 나타나지 않는 문제를 해결했습니다
서버에서 받은 옵션 데이터들 순서를 그대로 map 돌리지 않고 active 된 옵션들을 앞으로 이동하는 함수를 만들었습니다

```javasciprt
 function optChipSort(selectOptions) {
    const filtered = selectOptions.filter((option) => activeStates[option.id]);
    const remaining = selectOptions.filter(
      (option) => !activeStates[option.id],
    );
    return [...filtered, ...remaining];
  }
```


[issue] #172