### PR TITLE
[FE] 아카이빙 상세페이지 내 옵션 넘버링

### DIFF
--- a/FrontEnd/my-car/src/archiving/components/DetailBanner.js
+++ b/FrontEnd/my-car/src/archiving/components/DetailBanner.js
@@ -1,4 +1,4 @@
-import { styled } from 'styled-components';
+import { styled, css } from 'styled-components';
 import palette from '../../style/styleVariable';
 import PalisadeImg from '../../assets/palisadeImg.png';
 import { ReactComponent as DetailDivisionSvg } from '../../assets/archivingDetailDivision.svg';
@@ -130,9 +130,51 @@ const DescriptiveReviewSpan = styled.span`
   }
 `;
 
-function DetailBanner() {
-  const data = useContext(DataLoaderContext);
+const OptionPositionDiv = styled.div`
+  cursor: pointer;
+  width: 44px;
+  height: 44px;
+  flex-shrink: 0;
 
+  ${Body3Medium}
+  font-size: 24px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 40px; /* 166.667% */
+  letter-spacing: -1.2px;
+  z-index: 3;
+  border-radius: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  transform: translate(-50%, -50%);
+
+  background-color: white;
+  border: 4px solid
+    ${({ $selected }) => ($selected ? 'white' : `${palette.Primary}`)};
+  color: ${({ $selected }) => ($selected ? 'white' : `${palette.Primary}`)};
+  background-color: ${({ $selected }) =>
+    $selected ? `${palette.Primary}` : 'white'};
+  ${({ $left, $top }) => css`
+    top: ${$top}%;
+    left: ${$left}%;
+  `}
+`;
+
+const ImgOptWrap = styled.div`
+  width: 850px;
+  height: 465px;
+  position: relative;
+`;
+
+function DetailBanner({ selectedIdx, setSelectedIdx }) {
+  const data = useContext(DataLoaderContext);
+  console.log(selectedIdx);
+
+  function toggleSelect(idx) {
+    setSelectedIdx((prevIdx) => (prevIdx === idx ? null : idx));
+  }
   return (
     <AllDiv>
       <BannerDiv>
@@ -140,7 +182,8 @@ function DetailBanner() {
           <TrimDiv>
             <TrimTitleDiv>
               <TrimTitleText>
-                펠리세이드 {data[ARCHIVINGDETAIL.SELECTEDCAR.FILED.TRIM]}
+                {data[ARCHIVINGDETAIL.SELECTEDCAR.FILED.NAME]}{' '}
+                {data[ARCHIVINGDETAIL.SELECTEDCAR.FILED.TRIM]}
               </TrimTitleText>
               <ReviewDate>23년 7월 19일</ReviewDate>
               <ReviewGroup>시승</ReviewGroup>
@@ -174,7 +217,25 @@ function DetailBanner() {
           </DescriptiveReviewDiv>
         </TextDiv>
         <ImgDiv>
-          <img alt="img" src={PalisadeImg}></img>
+          <ImgOptWrap>
+            <img alt="img" src={PalisadeImg} />
+            {data.extraOptionForCarReviewDTOs.map((item, idx) => {
+              return item.x_position !== -1 ? (
+                <OptionPositionDiv
+                  onClick={() => toggleSelect(idx)}
+                  key={idx + 1}
+                  $left={item.x_position}
+                  $top={item.y_position}
+                  $selected={selectedIdx === idx}
+                >
+                  {'0'}
+                  {idx + 1}
+                </OptionPositionDiv>
+              ) : (
+                <></>
+              );
+            })}
+          </ImgOptWrap>
         </ImgDiv>
       </BannerDiv>
     </AllDiv>

--- a/FrontEnd/my-car/src/archiving/components/DetailBanner.js
+++ b/FrontEnd/my-car/src/archiving/components/DetailBanner.js
@@ -3,11 +3,13 @@ import palette from '../../style/styleVariable';
 import PalisadeImg from '../../assets/palisadeImg.png';
 import { ReactComponent as DetailDivisionSvg } from '../../assets/archivingDetailDivision.svg';
 import {
+  Body1Medium,
   Body1Regular,
   Body3Medium,
   Body3Regular,
   Body4Medium,
   Heading1Bold,
+  Heading3Medium,
 } from '../../style/typo';
 import { useContext } from 'react';
 import { ARCHIVINGDETAIL } from '../../constant';
@@ -90,7 +92,7 @@ const ColorContentText = styled.span`
 
 const ImgDiv = styled.div`
   display: flex;
-  transform: translate(0%, -65%);
+  transform: translate(0%, -70%);
   z-index: 1;
   margin: 0 auto;
   width: 1350px;
@@ -99,21 +101,35 @@ const ImgDiv = styled.div`
 
 const DescriptiveReviewDiv = styled.div`
   width: 381px;
+  height: 130px;
   color: ${palette.DarkGray};
   ${Body3Regular};
-  background-color: ${palette.Neutral};
-  height: 100px;
+  background-color: white;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  gap: 10px;
   border-radius: 8px;
-  border: 1px solid ${palette.LightGray};
+  border: 1.3px solid ${palette.LightGray};
   overflow: hidden;
   white-space: normal;
   padding: 12px 17px 12px 17px;
 `;
-const DescriptiveReviewSpan = styled.span`
-  overflow-y: auto;
 
+const OptReviewDiv = styled.div`
+  width: 381px;
+  height: 130px;
+  border-radius: 8px;
+  border: 1.3px solid ${palette.Primary};
+  background-color: ${palette.Neutral};
+  padding: 12px 17px 12px 17px;
+  display: flex;
+  gap: 10px;
+  flex-direction: column;
+`;
+const DescriptiveReviewSpan = styled.span`
+  color: ${palette.DarkGray};
+  overflow-y: auto;
+  margin: 5px 2px 0 2px;
   &::-webkit-scrollbar {
     width: 10px;
   }
@@ -168,13 +184,51 @@ const ImgOptWrap = styled.div`
   position: relative;
 `;
 
+const EachTagDiv = styled.div`
+  padding: 4px 8px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  ${Body3Regular};
+  border-radius: 8px;
+  background-color: ${palette.LightSand};
+  width: max-content;
+  height: max-content;
+  margin: 0 7px 7px 0;
+`;
+
+const EachTagSpan = styled.span``;
+const CardText = styled.span`
+  padding-top: 5px;
+  ${Body1Medium}
+  font-size: 18px;
+  color: ${({ $isDetailReview }) =>
+    $isDetailReview ? `${palette.DarkGray}` : `${palette.Primary}`};
+`;
+
+const CardLineSvg = styled.div`
+  width: 100%;
+  height: 1.3px;
+  background-color: ${({ $isDetailReview }) =>
+    $isDetailReview ? `${palette.LightGray}` : `${palette.Primary}`};
+`;
+
+const CardTagsDiv = styled.div`
+  display: flex;
+  overflow: auto;
+  flex-wrap: wrap;
+  z-index: 3;
+  margin-top: 5px;
+`;
+
 function DetailBanner({ selectedIdx, setSelectedIdx }) {
   const data = useContext(DataLoaderContext);
-  console.log(selectedIdx);
 
   function toggleSelect(idx) {
     setSelectedIdx((prevIdx) => (prevIdx === idx ? null : idx));
   }
+  const extraOptData = data[ARCHIVINGDETAIL.SELECTEDCAR.FILED.EXTRAOPTIONS];
+  console.log(extraOptData);
   return (
     <AllDiv>
       <BannerDiv>
@@ -210,11 +264,32 @@ function DetailBanner({ selectedIdx, setSelectedIdx }) {
             </ColorDetailDiv>
           </ColorDiv>
           <DetailDivisionSvg />
-          <DescriptiveReviewDiv>
-            <DescriptiveReviewSpan>
-              {data[ARCHIVINGDETAIL.SELECTEDCAR.FILED.COMMENT]}
-            </DescriptiveReviewSpan>
-          </DescriptiveReviewDiv>
+
+          {selectedIdx === null ? (
+            <DescriptiveReviewDiv>
+              <CardText $isDetailReview={true}>상세 후기</CardText>
+              <CardLineSvg $isDetailReview={true} />
+              <DescriptiveReviewSpan>
+                {data[ARCHIVINGDETAIL.SELECTEDCAR.FILED.COMMENT]}
+              </DescriptiveReviewSpan>
+            </DescriptiveReviewDiv>
+          ) : (
+            <OptReviewDiv>
+              <CardText>{extraOptData[selectedIdx].name}</CardText>
+              <CardLineSvg />
+              <CardTagsDiv>
+                {extraOptData[selectedIdx].extraOptionTagInfoDTOS.map(
+                  (item) => {
+                    return (
+                      <EachTagDiv>
+                        <EachTagSpan key={item.id}>{item.name}</EachTagSpan>
+                      </EachTagDiv>
+                    );
+                  },
+                )}
+              </CardTagsDiv>
+            </OptReviewDiv>
+          )}
         </TextDiv>
         <ImgDiv>
           <ImgOptWrap>

--- a/FrontEnd/my-car/src/archiving/components/EachOptCard.js
+++ b/FrontEnd/my-car/src/archiving/components/EachOptCard.js
@@ -1,10 +1,7 @@
 import { styled } from 'styled-components';
 import palette from '../../style/styleVariable';
 import { Body3Regular, CaptionRegular, Heading3Medium } from '../../style/typo';
-// import { ReactComponent as CardDivisionSvg } from '../../assets/optionCardDivision.svg';
-import { useContext, useState } from 'react';
-import { DataLoaderContext } from '../router/ArchivingDetail';
-import { ARCHIVINGDETAIL } from '../../constant';
+
 const CardDiv = styled.div`
   width: 307px;
   height: 320px;
@@ -19,12 +16,13 @@ const CardDiv = styled.div`
 
   padding: 20px 12px;
   cursor: pointer;
+
   &:hover {
     background-color: ${({ $isSelected }) =>
       $isSelected ? 'rgba(0, 44, 95, 0.1)' : `${palette.Neutral}`};
 
     & img {
-      transform: scale(1.2);
+      transform: scale(1.1);
       transition: 0.5s ease;
     }
   }

--- a/FrontEnd/my-car/src/archiving/router/ArchivingDetail.js
+++ b/FrontEnd/my-car/src/archiving/router/ArchivingDetail.js
@@ -21,39 +21,6 @@ const AllDiv = styled.div`
   width: 1055px;
 `;
 
-const dummyData = [
-  {
-    title: '컴포트 || 패키지',
-    discription: [
-      '후석 승객 알림',
-      '메탈 리어범퍼스텝',
-      '메탈 도어스커프',
-      '3열 파워 폴딩시트',
-      '3열 열선시트',
-      '헤드업 디스플레이',
-    ],
-    tags: ['편리해요😉', '출퇴근용으로 딱🚶', '어린이👶'],
-  },
-  {
-    title: '현대 스마트센스Ⅰ패키지',
-    discription: [
-      '전방 충돌방지 보조',
-      '내비게이션 기반 스마트 크루 즈 컨트롤',
-      '고속도로 주행보조 2',
-    ],
-    tags: ['편리해요😉', '출퇴근용으로 딱🚶', '어린이👶'],
-  },
-  {
-    title: '2열 통풍시트',
-    discription: [],
-    tags: ['편리해요😉', '출퇴근용으로 딱🚶', '어린이👶'],
-  },
-  {
-    title: '빌트인 캠(보조배터리 포함)',
-    discription: [],
-    tags: ['편리해요😉', '출퇴근용으로 딱🚶', '어린이👶'],
-  },
-];
 function ArchivingDetail() {
   const { id } = useParams();
   const { data } = useLoaderData();

--- a/FrontEnd/my-car/src/archiving/router/ArchivingDetail.js
+++ b/FrontEnd/my-car/src/archiving/router/ArchivingDetail.js
@@ -71,10 +71,12 @@ function ArchivingDetail() {
   return (
     <DataLoaderContext.Provider value={data}>
       <Container>
-        <DetailBanner />
+        <DetailBanner
+          selectedIdx={selectedIdx}
+          setSelectedIdx={setSelectedIdx}
+        />
         <AdditionalInfo />
         <AllDiv>
-          {/* {data[ARCHIVINGDETAIL.SELECTEDCAR.FILED.EXTRAOPTIONS] && } */}
           {data[ARCHIVINGDETAIL.SELECTEDCAR.FILED.EXTRAOPTIONS] &&
             data[ARCHIVINGDETAIL.SELECTEDCAR.FILED.EXTRAOPTIONS].map(
               (item, idx) => {

--- a/FrontEnd/my-car/src/constant.js
+++ b/FrontEnd/my-car/src/constant.js
@@ -68,6 +68,7 @@ export const ARCHIVINGDETAIL = {
   SELECTEDCAR: {
     URL: 'reviews/',
     FILED: {
+      NAMEL: 'car_name',
       PRICE: 'price',
       COMMENT: 'comment',
       TRIM: 'trim_name',
@@ -78,7 +79,6 @@ export const ARCHIVINGDETAIL = {
       EXCOLOR: 'exterior_color_name',
       DATE: 'created_at',
       EXTRAOPTIONS: 'extraOptionForCarReviewDTOs',
-      IMG: {},
     },
   },
 };


### PR DESCRIPTION
## 아카이빙 상세 페이지 내 옵션 넘버링 활성화를 구현하였습니다.

#### 차량 이미지 위에 있는 옵션 넘버링을 클릭할 시 -> 하단의 옵션 카드 활성화(반대의 경우도 가능)
#### 옵션들이 활성화 되었을 시 배너 좌측에 상세 후기 카드가 옵션에 대한 태그 후기로 변화합니다.



https://github.com/softeerbootcamp-2nd/A4-FourEver/assets/62049151/7bb7753f-0ce6-496c-921c-d1c5a0320ce4


