### PR TITLE
[FE] 아카이빙 배너 아래부분 선택옵션-> 차량 총 후기로 변경

### DIFF
--- a/FrontEnd/my-car/src/archiving/components/AdditionalInfo.js
+++ b/FrontEnd/my-car/src/archiving/components/AdditionalInfo.js
@@ -1,6 +1,7 @@
 import { styled } from 'styled-components';
 import palette from '../../style/styleVariable';
 import {
+  Body1Medium,
   Body1Regular,
   Body3Medium,
   Body3Regular,
@@ -35,7 +36,6 @@ const AdditionalInfoDiv = styled.div`
   display: flex;
   width: 1040px;
   justify-content: space-between;
-  align-items: center;
   gap: 89px;
   padding-top: 54px;
 `;
@@ -65,9 +65,10 @@ const EachTagReviewDiv = styled.div`
   justify-content: center;
   align-items: center;
   gap: 10px;
-  border-radius: 4px;
+  border-radius: 8px;
   border: 0.5px solid ${palette.LightGray};
   color: ${palette.DarkGray};
+  background-color: ${palette.LightSand};
   ${Body3Regular}
   width: max-content;
   height: 22px;
@@ -77,7 +78,7 @@ const WithThisCarDiv = styled.div`
   display: flex;
   gap: 14px;
   justify-content: center;
-  align-items: center;
+  height: fit-content;
 `;
 const SaveCarDiv = styled.div`
   width: 52px;
@@ -97,6 +98,7 @@ const MakingMycarBtn = styled.div`
   border: none;
   background-color: ${palette.Primary};
   ${Heading4Bold}
+  font-weight: 400;
   color: ${palette.LightSand};
   display: flex;
   justify-content: center;
@@ -104,9 +106,17 @@ const MakingMycarBtn = styled.div`
   cursor: pointer;
 `;
 
+const SelectedOptTitle = styled.div`
+  ${Body1Medium}
+  padding-top: 100px;
+  font-size: 24px;
+  font-weight: 500;
+  color: black;
+`;
+
 function AdditionalInfo() {
   const data = useContext(DataLoaderContext);
-
+  console.log(data);
   return (
     <AllDiv>
       <PriceDiv>
@@ -117,18 +127,17 @@ function AdditionalInfo() {
       </PriceDiv>
       <AdditionalInfoDiv>
         <TagReviewDiv>
-          <TagReviewTitle>
-            선택옵션{' '}
-            {data[ARCHIVINGDETAIL.SELECTEDCAR.FILED.EXTRAOPTIONS].length}
-          </TagReviewTitle>
+          <TagReviewTitle>차량 사용 후기</TagReviewTitle>
           <TagReviewsDiv>
-            {data[ARCHIVINGDETAIL.SELECTEDCAR.FILED.EXTRAOPTIONS] &&
-              data[ARCHIVINGDETAIL.SELECTEDCAR.FILED.EXTRAOPTIONS].map(
-                (item) => {
-                  return <EachTagReviewDiv>{item.name}</EachTagReviewDiv>;
-                },
-              )}
+            {data[ARCHIVINGDETAIL.SELECTEDCAR.FILED.TOTALTAGS] &&
+              data[ARCHIVINGDETAIL.SELECTEDCAR.FILED.TOTALTAGS].map((item) => {
+                return <EachTagReviewDiv>{item.name}</EachTagReviewDiv>;
+              })}
           </TagReviewsDiv>
+          <SelectedOptTitle>
+            선택 옵션{' '}
+            {data[ARCHIVINGDETAIL.SELECTEDCAR.FILED.EXTRAOPTIONS].length}
+          </SelectedOptTitle>
         </TagReviewDiv>
         <WithThisCarDiv>
           <SaveCarDiv>

--- a/FrontEnd/my-car/src/archiving/components/DetailBanner.js
+++ b/FrontEnd/my-car/src/archiving/components/DetailBanner.js
@@ -111,7 +111,7 @@ const DescriptiveReviewDiv = styled.div`
   flex-direction: column;
   gap: 10px;
   border-radius: 8px;
-  border: 1.3px solid ${palette.LightGray};
+  border: 2px solid ${palette.LightGray};
   overflow: hidden;
   white-space: normal;
   padding: 12px 17px 12px 17px;
@@ -121,7 +121,7 @@ const OptReviewDiv = styled.div`
   width: 381px;
   height: 130px;
   border-radius: 8px;
-  border: 1.3px solid ${palette.Primary};
+  border: 2px solid ${palette.Blue500};
   background-color: ${palette.Neutral};
   padding: 12px 17px 12px 17px;
   display: flex;
@@ -160,14 +160,14 @@ const OptionPositionDiv = styled.div`
   font-weight: 700;
   line-height: 40px; /* 166.667% */
   letter-spacing: -1.2px;
-  z-index: 3;
+  z-index: 2;
   border-radius: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
   position: absolute;
   transform: translate(-50%, -50%);
-
+  transition: all 0.2s ease;
   background-color: white;
   border: 4px solid
     ${({ $selected }) => ($selected ? 'white' : `${palette.Primary}`)};
@@ -178,6 +178,10 @@ const OptionPositionDiv = styled.div`
     top: ${$top}%;
     left: ${$left}%;
   `}
+
+  &:hover {
+    filter: brightness(0.85);
+  }
 `;
 
 const ImgOptWrap = styled.div`
@@ -205,14 +209,14 @@ const CardText = styled.span`
   ${Body1Medium}
   font-size: 18px;
   color: ${({ $isDetailReview }) =>
-    $isDetailReview ? `${palette.DarkGray}` : `${palette.Primary}`};
+    $isDetailReview ? `${palette.DarkGray}` : `${palette.Blue500}`};
 `;
 
 const CardLineSvg = styled.div`
   width: 100%;
   height: 1.3px;
   background-color: ${({ $isDetailReview }) =>
-    $isDetailReview ? `${palette.LightGray}` : `${palette.Primary}`};
+    $isDetailReview ? `${palette.LightGray}` : `${palette.Blue500}`};
 `;
 
 const CardTagsDiv = styled.div`

--- a/FrontEnd/my-car/src/archiving/components/EachOptCard.js
+++ b/FrontEnd/my-car/src/archiving/components/EachOptCard.js
@@ -3,27 +3,30 @@ import palette from '../../style/styleVariable';
 import { Body3Regular, CaptionRegular, Heading3Medium } from '../../style/typo';
 
 const CardDiv = styled.div`
-  width: 307px;
-  height: 320px;
+  width: 302px;
+  height: 300px;
   flex-shrink: 0;
   border-radius: 8px;
   border: 2px solid
     ${({ $isSelected }) =>
-      $isSelected ? `${palette.Primary}` : `${palette.Sand}`};
+      $isSelected ? `${palette.Blue500}` : `${palette.Sand}`};
   overflow: hidden;
   display: flex;
   flex-direction: column;
-
-  padding: 20px 12px;
+  padding: 12px;
   cursor: pointer;
+  img {
+    transition: 0.3s ease;
+  }
 
   &:hover {
+    filter: brightness(0.96);
+    transition: filter 0.3s ease;
     background-color: ${({ $isSelected }) =>
       $isSelected ? 'rgba(0, 44, 95, 0.1)' : `${palette.Neutral}`};
 
     & img {
       transform: scale(1.1);
-      transition: 0.5s ease;
     }
   }
 
@@ -36,6 +39,7 @@ const CardImgDiv = styled.div`
   justify-content: center;
   align-items: center;
   display: flex;
+  border-radius: 8px;
   &:hover {
     overflow: hidden;
   }
@@ -43,9 +47,9 @@ const CardImgDiv = styled.div`
 
 const CardImg = styled.img`
   background-color: lightgrey;
-  margin: 7px 12px;
-  object-fit: cover;
 
+  object-fit: cover;
+  border-radius: 8px;
   width: 100%;
   height: auto;
 `;
@@ -82,9 +86,11 @@ const CardNumber = styled.div`
 `;
 
 const CardDivisionSvg = styled.div`
-  width: 307px;
+  width: 302px;
   height: 1.5px;
-  background-color: #e4dcd3;
+  background-color: ${({ $isSelected }) =>
+    $isSelected ? `${palette.Blue500}` : `#e4dcd3`};
+
   margin-bottom: 5px;
 `;
 
@@ -97,8 +103,8 @@ const CardTagDiv = styled.div`
   width: 300px;
   flex-wrap: wrap;
   align-items: center;
-  padding: 5px;
-  height: 80px;
+  margin: 10px 0;
+  height: 65px;
   overflow: auto;
 `;
 const EachTagDiv = styled.div`
@@ -160,7 +166,7 @@ function EachOptCard({ data, idx, isSelected, onClick }) {
         )}
       </CardTitleOptDiv>
 
-      <CardDivisionSvg />
+      <CardDivisionSvg $isSelected={isSelected} />
       <CardTagDiv>
         {data.extraOptionTagInfoDTOS.map((item) => {
           return <EachTagDiv key={item.id}>{item.name}</EachTagDiv>;

--- a/FrontEnd/my-car/src/archiving/router/ArchivingDetail.js
+++ b/FrontEnd/my-car/src/archiving/router/ArchivingDetail.js
@@ -14,11 +14,11 @@ const Container = styled.div`
 
 const AllDiv = styled.div`
   display: flex;
-  margin: 50px auto;
+  margin: 20px auto;
   align-items: center;
   gap: 24px;
   flex-wrap: wrap;
-  width: 1055px;
+  width: 1040px;
 `;
 
 function ArchivingDetail() {

--- a/FrontEnd/my-car/src/common/Header.js
+++ b/FrontEnd/my-car/src/common/Header.js
@@ -20,7 +20,7 @@ const HeaderDiv = styled.div`
   padding: 0 90px 0 90px;
   position: fixed;
   top: 0;
-  z-index: 3;
+  z-index: 5;
 `;
 
 const HeaderElements = styled.div`

--- a/FrontEnd/my-car/src/constant.js
+++ b/FrontEnd/my-car/src/constant.js
@@ -80,6 +80,7 @@ export const ARCHIVINGDETAIL = {
       DATE: 'created_at',
       EXTRAOPTIONS: 'extraOptionForCarReviewDTOs',
       PURCHASE: 'is_purchased',
+      TOTALTAGS: 'totalTagInfoDTOs',
     },
   },
 };


### PR DESCRIPTION
배너 아래 추가적인 정보가 표시되어있는 부분에 기존에 선택옵션을 차량 총 후기 태그로 바꾸었습니다 
<img width="706" alt="스크린샷 2023-08-17 오후 6 52 08" src="https://github.com/softeerbootcamp-2nd/A4-FourEver/assets/62049151/38a20e40-5290-4297-9af3-a7465dee64e0">

<img width="706" alt="스크린샷 2023-08-17 오후 6 53 07" src="https://github.com/softeerbootcamp-2nd/A4-FourEver/assets/62049151/dd25bacf-f949-4997-80b8-cd8070751915">

[issue] #166