### PR TITLE
[FE] 아카이빙 메인페이지 디자인 수정

### DIFF
--- a/FrontEnd/my-car/src/archiving/components/DetailBanner.js
+++ b/FrontEnd/my-car/src/archiving/components/DetailBanner.js
@@ -315,8 +315,7 @@ function DetailBanner({ selectedIdx, setSelectedIdx }) {
                   $top={item.y_position}
                   $selected={selectedIdx === idx}
                 >
-                  {'0'}
-                  {idx + 1}
+                  {String(idx + 1).padStart(2, '0')}
                 </OptionPositionDiv>
               ) : (
                 <></>

--- a/FrontEnd/my-car/src/archiving/components/OptReviewCard.js
+++ b/FrontEnd/my-car/src/archiving/components/OptReviewCard.js
@@ -38,7 +38,8 @@ const CardWrap = styled.div`
   transition: all 0.2s;
   &:hover {
     border: 2px solid #aea6a0;
-    background: #fafafa;
+    /* background: #fafafa; */
+    filter: brightness(0.93);
   }
 `;
 
@@ -115,8 +116,11 @@ const CategoryWrap = styled.div`
     display: flex;
     flex-wrap: wrap;
     gap: 8px;
-    height: ${({ $isTags }) => ($isTags ? '22px' : 'auto')};
-    overflow-y: ${({ $isTags }) => ($isTags ? 'hidden' : 'none')};
+    height: ${({ $isTags }) => ($isTags ? '22px' : '70px')};
+    overflow-y: hidden;
+    button {
+      height: 30px;
+    }
   }
 `;
 

--- a/FrontEnd/my-car/src/archiving/components/OptReviewCard.js
+++ b/FrontEnd/my-car/src/archiving/components/OptReviewCard.js
@@ -29,14 +29,11 @@ const CardWrap = styled.div`
   width: calc(470px - 60px);
   height: 220px;
   border-radius: 8px;
-  /* border: 1px solid var(--hyundai-sand, #e4dcd3); */
   border: 2px solid #e4dcd3;
 
   background: #fff;
   padding: 26px;
-  &:nth-child(2n + 1) {
-    /* margin-left: 30px; */
-  }
+
   cursor: pointer;
   transition: all 0.2s;
   &:hover {

--- a/FrontEnd/my-car/src/archiving/components/OptReviewCard.js
+++ b/FrontEnd/my-car/src/archiving/components/OptReviewCard.js
@@ -17,24 +17,25 @@ import NoItem from './NoItem';
 
 const Container = styled.div`
   width: calc(1280px - 240px);
-  margin: 0 auto 50px;
+  margin: 25px auto;
   padding: 0 120px;
   display: flex;
   flex-wrap: wrap;
   gap: 32px;
+  justify-content: center;
 `;
 
 const CardWrap = styled.div`
   width: calc(470px - 60px);
-  height: 270px;
+  height: 220px;
   border-radius: 8px;
   /* border: 1px solid var(--hyundai-sand, #e4dcd3); */
   border: 2px solid #e4dcd3;
 
   background: #fff;
-  padding: 30px;
+  padding: 26px;
   &:nth-child(2n + 1) {
-    margin-left: 30px;
+    /* margin-left: 30px; */
   }
   cursor: pointer;
   transition: all 0.2s;
@@ -47,7 +48,6 @@ const CardWrap = styled.div`
 const CardHeader = styled.div`
   display: flex;
   justify-content: space-between;
-
   margin-bottom: 20px;
 `;
 const TrimInfo = styled.div`
@@ -69,10 +69,10 @@ const TrimInfo = styled.div`
 
 const RestInfoChip = styled.div`
   color: ${palette.Gold};
-  background-color: ${palette.LightSand};
+  background-color: ${palette.Sand};
   height: 20px;
   padding: 2px 8px;
-  border-radius: 15px;
+  border-radius: 8px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -106,16 +106,20 @@ const ColorWrap = styled.div`
 const CategoryWrap = styled.div`
   display: flex;
   gap: 15px;
-  margin-bottom: 20px;
+  margin-bottom: 15px;
+
   h3 {
     ${Body3Medium}
     color: #3F3F3F;
     flex-shrink: 0;
+    padding-top: 4px;
   }
   div {
     display: flex;
     flex-wrap: wrap;
     gap: 8px;
+    height: ${({ $isTags }) => ($isTags ? '22px' : 'auto')};
+    overflow-y: ${({ $isTags }) => ($isTags ? 'hidden' : 'none')};
   }
 `;
 
@@ -180,9 +184,9 @@ function OptReviewCard() {
                     ))}
                 </div>
               </CategoryWrap>
-              <CategoryWrap>
+              <CategoryWrap $isTags={true}>
                 <h3>태그후기</h3>
-                <div>
+                <div style={{ height: '30px' }}>
                   {review.totalTagInfoDTOs.slice(0, 3).map((tag, index) => (
                     <Tag key={index}>{tag.name}</Tag>
                   ))}

--- a/FrontEnd/my-car/src/archiving/components/OptReviewHeader.js
+++ b/FrontEnd/my-car/src/archiving/components/OptReviewHeader.js
@@ -14,9 +14,8 @@ export const Container = styled.div`
 `;
 
 const TabText = styled.span`
-  border-radius: 8px;
-  height: 25px;
-
+  height: 24px;
+  border-radius: 3px;
   ${({ $isActive }) =>
     $isActive
       ? css`

--- a/FrontEnd/my-car/src/archiving/components/OptReviewHeader.js
+++ b/FrontEnd/my-car/src/archiving/components/OptReviewHeader.js
@@ -15,7 +15,6 @@ export const Container = styled.div`
 
 const TabText = styled.span`
   height: 24px;
-  /* border-radius: 3px; */
 
   ${({ $isActive }) =>
     $isActive
@@ -32,8 +31,6 @@ const TabText = styled.span`
 `;
 
 const HeaderWrap = styled.div`
-  /* border-bottom: 1px solid ${palette.LightGray}; */
-  /* border-bottom: 2px solid #e4dcd396; */
   gap: 16px;
   display: flex;
   align-items: flex-end;
@@ -56,12 +53,6 @@ const TabWrap = styled.div`
     margin: 0 5px;
     padding: 0 3px;
     width: 28px;
-    /* &:first-child {
-      padding-left: 0;
-    }
-    &:last-child {
-      padding-right: 0;
-    } */
   }
 `;
 

--- a/FrontEnd/my-car/src/archiving/components/OptReviewHeader.js
+++ b/FrontEnd/my-car/src/archiving/components/OptReviewHeader.js
@@ -14,29 +14,38 @@ export const Container = styled.div`
 `;
 
 const TabText = styled.span`
+  border-radius: 8px;
+  height: 25px;
+
   ${({ $isActive }) =>
     $isActive
       ? css`
           ${Body2Medium}
           font-weight: bolder;
+          color: ${palette.DarkGray};
+          background-color: ${palette.LightSand};
         `
       : css`
           ${Body2Regular}
+          color: ${palette.DarkGray};
         `}
 `;
 
 const HeaderWrap = styled.div`
   /* border-bottom: 1px solid ${palette.LightGray}; */
-  border-bottom: 2px solid #e4dcd396;
+  /* border-bottom: 2px solid #e4dcd396; */
   gap: 20px;
   display: flex;
   align-items: flex-end;
+  gap: 20px;
+  display: flex;
+  align-items: flex-end;
+  padding: 15px 0 0 0;
+  width: 960px;
+  margin: 0 auto;
   h1 {
     ${Heading2Bold}
   }
-
-  padding: 15px 0;
-  margin: 0 150px;
 `;
 
 const TabWrap = styled.div`
@@ -44,14 +53,13 @@ const TabWrap = styled.div`
 
   span {
     cursor: pointer;
-
     padding: 0 10px;
-    &:first-child {
+    /* &:first-child {
       padding-left: 0;
     }
     &:last-child {
       padding-right: 0;
-    }
+    } */
   }
 `;
 
@@ -66,7 +74,7 @@ function OptReviewHeader() {
   return (
     <Container>
       <HeaderWrap>
-        <h1>사용후기</h1>
+        <h1>사용후기 </h1>
         <TabWrap>
           {ArchivingTabMenu.map((tab, index) => (
             <TabText

--- a/FrontEnd/my-car/src/archiving/components/OptReviewHeader.js
+++ b/FrontEnd/my-car/src/archiving/components/OptReviewHeader.js
@@ -15,30 +15,31 @@ export const Container = styled.div`
 
 const TabText = styled.span`
   height: 24px;
-  border-radius: 3px;
+  /* border-radius: 3px; */
+
   ${({ $isActive }) =>
     $isActive
       ? css`
           ${Body2Medium}
           font-weight: bolder;
           color: ${palette.DarkGray};
-          background-color: ${palette.LightSand};
+          border-bottom: 2px solid;
         `
       : css`
           ${Body2Regular}
-          color: ${palette.DarkGray};
+          color: ${palette.MediumGray};
         `}
 `;
 
 const HeaderWrap = styled.div`
   /* border-bottom: 1px solid ${palette.LightGray}; */
   /* border-bottom: 2px solid #e4dcd396; */
-  gap: 20px;
+  gap: 16px;
   display: flex;
   align-items: flex-end;
   gap: 20px;
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   padding: 15px 0 0 0;
   width: 960px;
   margin: 0 auto;
@@ -52,7 +53,9 @@ const TabWrap = styled.div`
 
   span {
     cursor: pointer;
-    padding: 0 10px;
+    margin: 0 5px;
+    padding: 0 3px;
+    width: 28px;
     /* &:first-child {
       padding-left: 0;
     }

--- a/FrontEnd/my-car/src/archiving/components/OptSelectionBar.js
+++ b/FrontEnd/my-car/src/archiving/components/OptSelectionBar.js
@@ -1,15 +1,12 @@
 import { css, styled } from 'styled-components';
 import palette from '../../style/styleVariable';
 import { Body3Regular } from '../../style/typo';
-import { useContext, useEffect, useState } from 'react';
+import { useContext } from 'react';
 import {
   OptionSelectAction,
   OptionSelectValue,
 } from '../../context/archiving/ArchivingProvider';
-import useFetch from '../hook/useFetch';
 import { ARCHIVING } from '../../constant';
-import ServerErrorPage from '../../error/ServerErrorPage';
-import { MakePath } from '../../api';
 
 const Container = styled.div`
   background-color: ${palette.Neutral};
@@ -29,7 +26,10 @@ const TagWrap = styled.div`
 
 export const OptTag = styled.button`
   border: 0;
-
+  transition: filter 0.2s ease;
+  &:hover {
+    filter: ${({ $inNavbar }) => ($inNavbar ? 'brightness(0.93)' : 'none')};
+  }
   ${({ $isActive }) =>
     $isActive
       ? css`
@@ -64,6 +64,7 @@ function OptSelectionBar() {
             onClick={() => ClickOption({ id: list.id })}
             key={index}
             $isActive={activeStates[list.id]}
+            $inNavbar={true}
           >
             {list.name}
           </OptTag>

--- a/FrontEnd/my-car/src/archiving/components/OptSelectionBar.js
+++ b/FrontEnd/my-car/src/archiving/components/OptSelectionBar.js
@@ -24,6 +24,7 @@ const TagWrap = styled.div`
   display: flex;
   flex-wrap: wrap;
   gap: 14px;
+  justify-content: center;
 `;
 
 export const OptTag = styled.button`


### PR DESCRIPTION
### 아카이빙 메인페이지 디자인을 변경하였습니다.
**- 옵션 선택 navbar 가운데 정렬**
**- 옵션 카드 내 후기 태그 한줄만 나오기**
**- 전체/시승/구매 탭 디자인**
**- 전반적인 width, height, 정렬 조절**
<img width="907" alt="스크린샷 2023-08-17 오후 11 29 59" src="https://github.com/softeerbootcamp-2nd/A4-FourEver/assets/62049151/f2c32a06-e0af-455b-be9b-87db8ab6012a">

