### PR TITLE
[FE] 카이빙 헤더 상태

### DIFF
--- a/FrontEnd/my-car/src/archiving/RootArchiving.js
+++ b/FrontEnd/my-car/src/archiving/RootArchiving.js
@@ -9,7 +9,7 @@ function RootArchiving() {
   return (
     <ArchivingProvider setLoading={setLoading}>
       <ChivingHeader fromMycar={state} />
-      <Outlet context={{ loading }} />
+      <Outlet context={{ loading, fromMycar: state }} />
     </ArchivingProvider>
   );
 }

--- a/FrontEnd/my-car/src/archiving/components/OptReviewCard.js
+++ b/FrontEnd/my-car/src/archiving/components/OptReviewCard.js
@@ -8,7 +8,7 @@ import {
 import palette from '../../style/styleVariable';
 import { OptTag } from './OptSelectionBar';
 import { Tag } from '../../common/Tag';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useOutletContext } from 'react-router-dom';
 import { useContext } from 'react';
 import { OptionSelectValue } from '../../context/archiving/ArchivingProvider';
 import { ARCHIVING } from '../../constant';
@@ -120,10 +120,11 @@ const CategoryWrap = styled.div`
 `;
 
 function OptReviewCard() {
+  const { fromMycar } = useOutletContext();
   const { activeStates, reviewList } = useContext(OptionSelectValue);
   const navigate = useNavigate();
   const CardClick = ({ id }) => {
-    navigate(`/archiving/${id}`);
+    navigate(`/archiving/${id}`, { state: { fromMycar } });
   };
 
   function optChipSort(selectOptions) {

--- a/FrontEnd/my-car/src/common/ChivingHeader.js
+++ b/FrontEnd/my-car/src/common/ChivingHeader.js
@@ -4,7 +4,7 @@ import ToBackSymbol from '../assets/leftArrow.svg';
 import { ReactComponent as ArchivingLogo } from '../assets/archivingLogoBlack.svg';
 import { ReactComponent as CarLogo } from '../assets/carLogo.svg';
 import { Heading3Medium, Heading4Medium } from '../style/typo';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { myCarPagePath } from '../constant';
 const ChivingHeaderDiv = styled.div`
   width: calc(100% - 180px);
@@ -66,6 +66,8 @@ const GoBack = styled.img`
 `;
 
 function ChivingHeader({ fromMycar }) {
+  const { state } = useLocation();
+
   const navigate = useNavigate();
   const BackClick = () => {
     navigate(-1);


### PR DESCRIPTION
카이빙 헤더 상태를 아카이빙 상세페이지에도 적용했습니다.
- 내차만들기 페이지 or 메인 페이지 -> 아카이빙 메인 -> 아카이빙 상세페이지에서 헤더에는 뒤로가기 버튼만 노출됩니다


<img width="1460" alt="스크린샷 2023-08-18 오전 10 42 55" src="https://github.com/softeerbootcamp-2nd/A4-FourEver/assets/101038390/76f54e79-2d9b-4d2e-b6e9-9757dda4092b">


[issue] #155