### PR TITLE
[FE] 아카이빙 상세페이지 내 이미지 변경

### DIFF
--- a/FrontEnd/my-car/src/archiving/components/DetailBanner.js
+++ b/FrontEnd/my-car/src/archiving/components/DetailBanner.js
@@ -1,6 +1,5 @@
 import { styled, css } from 'styled-components';
 import palette from '../../style/styleVariable';
-import PalisadeImg from '../../assets/palisadeImg.png';
 import { ReactComponent as DetailDivisionSvg } from '../../assets/archivingDetailDivision.svg';
 import {
   Body1Medium,
@@ -94,7 +93,7 @@ const ColorContentText = styled.span`
 
 const ImgDiv = styled.div`
   display: flex;
-  transform: translate(0%, -70%);
+  transform: translate(4%, -65%);
   z-index: 1;
   margin: 0 auto;
   width: 1350px;
@@ -185,8 +184,8 @@ const OptionPositionDiv = styled.div`
 `;
 
 const ImgOptWrap = styled.div`
-  width: 850px;
-  height: 465px;
+  width: 940px;
+  height: 515px;
   position: relative;
 `;
 
@@ -305,7 +304,10 @@ function DetailBanner({ selectedIdx, setSelectedIdx }) {
         </TextDiv>
         <ImgDiv>
           <ImgOptWrap>
-            <img alt="img" src={PalisadeImg} />
+            <img
+              alt="img"
+              src={data[ARCHIVINGDETAIL.SELECTEDCAR.FILED.EXCOLOR].color_image}
+            />
             {data.extraOptionForCarReviewDTOs.map((item, idx) => {
               return item.x_position !== -1 ? (
                 <OptionPositionDiv

--- a/FrontEnd/my-car/src/archiving/components/EachOptCard.js
+++ b/FrontEnd/my-car/src/archiving/components/EachOptCard.js
@@ -123,7 +123,7 @@ const PkgSubOptDiv = styled.div`
   opacity: ${({ $isSelected }) => ($isSelected ? '1' : '0')};
   height: ${({ $isSelected }) => ($isSelected ? '70px' : '0px')};
   overflow: hidden;
-  margin: 0 8px 8px;
+  margin: ${({ $isSelected }) => ($isSelected ? '0 8px 8px' : '0 8px')};
   transition: all 0.4s ease;
 `;
 const PkgSubOptText = styled.span`


### PR DESCRIPTION
## 아카이빙 상세페이지 내-이미지 변경
**아카이빙 상세페이지 내에서 사용자가 선택한 차량 색상이 보여지도록 이미지를 변경하였습니다.**

<img width="1035" alt="스크린샷 2023-08-18 오후 11 36 03" src="https://github.com/softeerbootcamp-2nd/A4-FourEver/assets/62049151/f9c3b6d3-7339-4814-8dfd-140c2b0edcad">


<img width="907" alt="스크린샷 2023-08-18 오후 11 34 27" src="https://github.com/softeerbootcamp-2nd/A4-FourEver/assets/62049151/8ff1c2b0-acf7-4ac6-ac40-81c72244fb59">


### ++옵션 카드 사진 height 통일하였습니다.

<img width="1035" alt="스크린샷 2023-08-18 오후 11 34 52" src="https://github.com/softeerbootcamp-2nd/A4-FourEver/assets/62049151/2bcced7c-b634-4878-a889-2803eedb262c">
