### PR TITLE
[fix] 아카이빙/온보딩 모달 스크롤 버그 해결 및 firstboarding 상태 추가

### DIFF
--- a/FrontEnd/my-car/src/archiving/components/Onboarding.js
+++ b/FrontEnd/my-car/src/archiving/components/Onboarding.js
@@ -11,8 +11,9 @@ import {
   Heading4Bold,
 } from '../../style/typo';
 import palette from '../../style/styleVariable';
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 import { Tag } from '../../common/Tag';
+import { ModalContext } from '../../context/archiving/ArchivingProvider';
 
 const Dim = styled.div`
   background-color: black;
@@ -101,19 +102,6 @@ const Header = styled.div`
   div {
     display: flex;
   }
-
-  ${({ $page }) =>
-    $page === 2
-      ? css`
-          .skip {
-            visibility: hidden;
-          }
-        `
-      : css`
-          .skip {
-            visibility: visible;
-          }
-        `}
 
   span {
     display: flex;
@@ -340,6 +328,7 @@ const TopWrap = styled.div`
 
 function Onboarding({ setModalShow, data }) {
   const [page, setPage] = useState(0);
+  const { setFirstBoarding } = useContext(ModalContext);
 
   const pageMove = () => {
     setPage((prev) => prev + 1);
@@ -363,7 +352,14 @@ function Onboarding({ setModalShow, data }) {
               <NextSvg />
             </div>
           ) : (
-            <span onClick={() => setModalShow(false)}>닫기</span>
+            <span
+              onClick={() => {
+                setModalShow(false);
+                setFirstBoarding(false);
+              }}
+            >
+              닫기
+            </span>
           )}
         </Header>
         <ViewWrap $page={(1 - page) * 800}>

--- a/FrontEnd/my-car/src/archiving/router/Archiving.js
+++ b/FrontEnd/my-car/src/archiving/router/Archiving.js
@@ -2,8 +2,10 @@ import { styled } from 'styled-components';
 import OptSelectionBar from '../components/OptSelectionBar';
 import OptReviewHeader from '../components/OptReviewHeader';
 import OptReviewCard from '../components/OptReviewCard';
-import ArchivingProvider from '../../context/archiving/ArchivingProvider';
-import { useEffect, useState } from 'react';
+import ArchivingProvider, {
+  ModalContext,
+} from '../../context/archiving/ArchivingProvider';
+import { useContext, useEffect, useState } from 'react';
 import { useLoaderData, useOutletContext } from 'react-router-dom';
 import WarningTooltip from '../components/WarningTooltip';
 import Loading from '../../common/Loading';
@@ -24,20 +26,22 @@ const FixedContainer = styled.div`
 `;
 
 function Archiving() {
+  const { data } = useLoaderData();
   const { loading } = useOutletContext();
+
+  //온보딩 모달 관련
+  const { firstBoarding } = useContext(ModalContext);
   const [modalShow, setModalShow] = useState(true);
   const onboardingOff = localStorage.getItem('onboardingOff');
 
-  const { data } = useLoaderData();
-
   useEffect(() => {
     const body = document.querySelector('body');
-    if (modalShow) {
+    if (modalShow && !onboardingOff) {
       body.classList.add('no-scroll');
     } else {
       body.classList.remove('no-scroll');
     }
-  }, [modalShow]);
+  }, [modalShow, onboardingOff]);
 
   return (
     <>
@@ -45,7 +49,7 @@ function Archiving() {
         <Loading text={'후기를 불러오는 중입니다'} />
       ) : (
         <>
-          {modalShow && !onboardingOff && (
+          {modalShow && !onboardingOff && firstBoarding && (
             <Onboarding data={data} setModalShow={setModalShow} />
           )}
           <Container>

--- a/FrontEnd/my-car/src/context/archiving/ArchivingProvider.js
+++ b/FrontEnd/my-car/src/context/archiving/ArchivingProvider.js
@@ -5,8 +5,11 @@ import useFetch from '../../archiving/hook/useFetch';
 
 export const OptionSelectValue = createContext();
 export const OptionSelectAction = createContext();
+export const ModalContext = createContext();
 
 function ArchivingProvider({ children, setLoading, fromMycar }) {
+  const [firstBoarding, setFirstBoarding] = useState(true);
+
   const accessToken = localStorage.getItem('jwtToken');
 
   const [activeStates, setActiveStates] = useState({}); //선택 옵션
@@ -45,6 +48,7 @@ function ArchivingProvider({ children, setLoading, fromMycar }) {
     }
   }, [reviewLoading, optionLoading, setLoading]);
 
+  console.log(firstBoarding);
   const action = {
     select: ({ id }) => {
       setActiveStates((prevActiveStates) => ({
@@ -68,6 +72,7 @@ function ArchivingProvider({ children, setLoading, fromMycar }) {
       setActiveTab(index);
     },
   };
+
   useEffect(() => {
     const userCar = JSON.parse(localStorage.getItem('userCar'));
     if (fromMycar?.fromMycar !== null && userCar) {
@@ -88,9 +93,16 @@ function ArchivingProvider({ children, setLoading, fromMycar }) {
   return (
     <OptionSelectAction.Provider value={{ action }}>
       <OptionSelectValue.Provider
-        value={{ activeStates, activeTab, optionList, reviewList }}
+        value={{
+          activeStates,
+          activeTab,
+          optionList,
+          reviewList,
+        }}
       >
-        {children}
+        <ModalContext.Provider value={{ firstBoarding, setFirstBoarding }}>
+          {children}
+        </ModalContext.Provider>
       </OptionSelectValue.Provider>
     </OptionSelectAction.Provider>
   );


### PR DESCRIPTION
-온보딩 모달 다시보지 않기 클릭한 경우, 다음 턴에 아카이빙에 진입했을때, 스크롤이 막혀있는 문제 해결했습니다
-온보딩 모달 닫기 클릭 후 아카이빙 상세페이지로 이동했다가 뒤로가기 수행 시 온보딩 모달 뜨지 않도록 수정했습니다

[issue] #254