### PR TITLE
[FE] 아카이빙 데이터 만료시간 설정

### DIFF
--- a/FrontEnd/my-car/src/archiving/hook/useFetch.js
+++ b/FrontEnd/my-car/src/archiving/hook/useFetch.js
@@ -1,39 +1,62 @@
 import { useEffect, useState } from 'react';
+import { MakePath } from '../../api';
+import { ARCHIVING } from '../../constant';
 
 const useFetch = ({ url, config, optionSelect, activeTab }) => {
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState();
-
-  const fetchData = async () => {
-    // console.log(url);
-    try {
-      const response = await fetch(url, { ...config });
-      const jsonData = await response.json();
-
-      if (config?.body) {
-        const body = JSON.parse(config.body);
-        const entire = { ...body, activeTab };
-        localStorage.setItem(JSON.stringify(entire), JSON.stringify(jsonData));
-      }
-      setData(jsonData);
-      setLoading(false);
-    } catch (error) {
-      setError(error);
-      setLoading(false);
-    }
-  };
+  const [controller, setController] = useState();
 
   useEffect(() => {
+    const fetchData = async () => {
+      // setController(new AbortController());
+      try {
+        const response = await fetch(url, {
+          ...config,
+          // signal: controller.signal,
+        });
+        const jsonData = await response.json();
+
+        if (config?.body) {
+          const body = JSON.parse(config.body);
+          const now = new Date();
+          const expirationMinutes = 0.1;
+          const expiration = now.getTime() + expirationMinutes * 60 * 1000;
+          const entire = { ...body, activeTab };
+          localStorage.setItem(
+            JSON.stringify(entire),
+            JSON.stringify({ data: jsonData, expiration }),
+          );
+        }
+        setData(jsonData);
+        setLoading(false);
+      } catch (error) {
+        console.log(error);
+        setError(error);
+        setLoading(false);
+      }
+    };
+
     const entire = { ...optionSelect, activeTab };
     const localData = localStorage.getItem(JSON.stringify(entire));
+
     if (localData) {
-      setData(JSON.parse(localData));
+      setData(JSON.parse(localData).data);
+
+      const data = JSON.parse(localData);
+      const now = new Date().getTime();
+      if (now > data.expiration) {
+        // controller?.abort();
+        fetchData();
+      }
+
       setLoading(false);
     } else {
       setLoading(true);
       fetchData();
     }
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [optionSelect, activeTab]);
 

--- a/FrontEnd/my-car/src/context/archiving/ArchivingProvider.js
+++ b/FrontEnd/my-car/src/context/archiving/ArchivingProvider.js
@@ -48,7 +48,6 @@ function ArchivingProvider({ children, setLoading, fromMycar }) {
     }
   }, [reviewLoading, optionLoading, setLoading]);
 
-  console.log(firstBoarding);
   const action = {
     select: ({ id }) => {
       setActiveStates((prevActiveStates) => ({


### PR DESCRIPTION
로컬 스토리지에 저장되어있는 아카이빙 데이터의 만료시간 필드를 추가하여 데이터가 만료 되었을 경우 
다시 로딩 화면을 그리지 않고 일단 기존 캐시 데이터를 보여준 다음 최신 데이터를 위해 새로운 패치를 진행햐여 자연스럽게 리렌더링되는 과정을 구현했습니다
(리액트 쿼리 라이브러리가 이런식으로 동작하는데, 따라해보려고 노력했습니다..!)

여기서 한가지 이슈는, 리패치가 6~7초정도 걸려서 6초가 지나기 전에 다른 옵션 조합을 클릭하면 이전 클릭 옵션의 리패치 결과가 나타난다는 것인데
패치를 무시하는 방법을 시도해보았으나... 잘 되지 않아서, 일단은 무시하는 부분은 주석처리 해놓았고 백엔드 최적화를 기다려봐야 할 것 같아요. 
최적화 되면 패치가 1초정도로 줄어준다고 들었어요!

https://github.com/softeerbootcamp-2nd/A4-FourEver/assets/101038390/4c9669f3-d422-4033-8421-e681b065423b

이 영상에서 console 창을 보시면 해당 기능에 대해 조금 이해가 되실것같습니다!!

[issue] #270