### PR TITLE
[FE] 360 이미지 png->webp 로 변경

### DIFF
--- a/FrontEnd/my-car/src/mycar/components/colorPage/RotateImg.js
+++ b/FrontEnd/my-car/src/mycar/components/colorPage/RotateImg.js
@@ -183,14 +183,14 @@ function RotateImg({ selectedOption, loading }) {
             <div class="l-9 letter">.</div>
             <div class="l-10 letter">.</div>
           </LetterWrap>
-          <img alt="" src={`${imagePathNew}/1.png`} />
+          <img alt="" src={`${imagePathNew}/1.webp`} />
         </LoadingWrap>
       ) : (
         Array.from({ length: 60 }, (_, index) => (
           <CarImg
             $isShow={index + 1 === imageIndex}
             alt="trim"
-            src={`${imagePathNew}/${index + 1}.png`}
+            src={`${imagePathNew}/${index + 1}.webp`}
           />
         ))
       )}

--- a/FrontEnd/my-car/src/mycar/routers/Color.js
+++ b/FrontEnd/my-car/src/mycar/routers/Color.js
@@ -57,7 +57,7 @@ function Color() {
         const imagePaths = Array.from(
           { length: 60 },
           (_, index) =>
-            `http://hyundaimycar.store/rotation/${color}/${index + 1}.png`,
+            `http://hyundaimycar.store/rotation/${color}/${index + 1}.webp`,
         );
         imagePaths.forEach((path) => {
           const img = new Image();


### PR DESCRIPTION
기존 png 이미지는 장당 152kb, webp 이미지는 장당 22kb 으로 용량 차이를 확인했습니다~~!
다운로드 속도가 훨씬 빨라졌다고 느껴졌습니다!

https://github.com/softeerbootcamp-2nd/A4-FourEver/assets/101038390/d55cb3e3-be52-47ec-bbc5-8ca17a1906d3

[issue] #251